### PR TITLE
Cleanup

### DIFF
--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_code)]
 pub mod manager;
 pub mod reports;
 

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_code)]
 mod files;
 
 pub use files::{DataType, Datapack, DatapackId, FileId, NamespaceId};

--- a/crates/mcf/src/lib.rs
+++ b/crates/mcf/src/lib.rs
@@ -1,1 +1,2 @@
+#![deny(unsafe_code)]
 pub mod syntax;

--- a/crates/nbt/src/lib.rs
+++ b/crates/nbt/src/lib.rs
@@ -1,1 +1,2 @@
+#![deny(unsafe_code)]
 pub mod value;

--- a/crates/nbt/src/value.rs
+++ b/crates/nbt/src/value.rs
@@ -42,7 +42,19 @@ impl TryFrom<u8> for TagType {
     type Error = NbtParseError;
     fn try_from(i: u8) -> Result<Self, Self::Error> {
         match i {
-            0..=12 => Ok(unsafe { std::mem::transmute(i) }),
+            0 => Ok(TagType::End),
+            1 => Ok(TagType::Byte),
+            2 => Ok(TagType::Short),
+            3 => Ok(TagType::Int),
+            4 => Ok(TagType::Long),
+            5 => Ok(TagType::Float),
+            6 => Ok(TagType::Double),
+            7 => Ok(TagType::ByteArray),
+            8 => Ok(TagType::String),
+            9 => Ok(TagType::List),
+            10 => Ok(TagType::Compound),
+            11 => Ok(TagType::IntArray),
+            12 => Ok(TagType::LongArray),
             _ => Err(NbtParseError::InvalidTagType(i)),
         }
     }

--- a/crates/nbtdoc/src/lib.rs
+++ b/crates/nbtdoc/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_code)]
 pub mod modules;
 pub mod syntax;
 

--- a/crates/parse/src/lib.rs
+++ b/crates/parse/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_code)]
 pub mod ast;
 pub mod error;
 pub mod parser;

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_code)]
 #[macro_use]
 pub mod arena;
 pub mod commands;

--- a/new_nbtdoc_syntax.md
+++ b/new_nbtdoc_syntax.md
@@ -1,30 +1,39 @@
 ## Tokens
 
 ### Quoted String: `QUOTED_STRING`
+
 > `"` ( `\` ~[ `\n` `\r` ] | ~[ `\n` `\r` `"` `\` ] )<sup>\*</sup> `"`
 
 ### Identifier: `IDENT`
+
 > [ `a`-`z`, `A`-`Z`, `_` ]<sup>+</sup>
 
 ### Whitespace: `WHITESPACE`
+
 > [ `\u0020` `\t` `\n` `\f` `\r` ]<sup>\*</sup>
 
-`\u0020` is a space  
+`\u0020` is a space
+
 ### Comment: `COMMENT`
+
 > `//` ~[ `\n` ]<sup>\*</sup>
 
 ### Doc Comment: `DOC_COMMENT`
+
 > `///` ~[ `\n` ]<sup>\*</sup>
 
 ### Float: `FLOAT`
+
 > `-`<sup>?</sup> ( \
 > &nbsp;&nbsp; `.` [ `0`-`9` ]<sup>+</sup>\
 > &nbsp;&nbsp; | [ `0`-`9` ]<sup>+</sup> ( `.` [ `0`-`9` ]<sup>+</sup> )<sup>?</sup>\
 > )\
-> ( [ `e` `E` ] [ `-`, `+` ]<sup>?</sup> [ `0`-`9` ]<sup>+</sup> )<sup>?</sup>
+> ( [ `e` `E` ][ `-`, `+` ]<sup>?</sup> [ `0`-`9` ]<sup>+</sup> )<sup>?</sup>
+
 ### Integer: `INTEGER`
+
 > `-`<sup>?</sup> [ `0`-`9` ]<sup>+</sup>
-  
+
 Parsing automatically skips `WHITESPACE`, `COMMENT`, and `DOC_COMMENT` tokens unless specified.
 
 ## Parser Rules


### PR DESCRIPTION
Remove and deny unsafe code - I don't think we have any reason to be using unsafe.

Also format a markdown file using `prettier`